### PR TITLE
Bug fixed & compression optimized using CSS color names

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,11 +9,18 @@ var base64ImageToRGBArray = require('./lib/base64ImageToRGBArray')
 function compressColor (rgb) {
   var hex = tinycolor(rgb).toHexString()
 
-  if (hex[1] === hex[2] && hex[3] === hex[4] && hex[5] === hex[6]) {
-    return '#' + hex[1] + hex[3] + hex[4]
-  } else {
-    return hex
+  switch (hex) { // based on CSS3 supported color names http://www.w3.org/TR/css3-color/
+    case '#c0c0c0': return 'silver';
+    case '#808080': return 'gray';
+    case '#800000': return 'maroon';
+    case '#ff0000': return 'red';
+    case '#800080': return 'purple';
+    case '#008000': return 'green';
+    case '#808000': return 'olive';
+    case '#000080': return 'navy';
+    case '#008080': return 'teal';
   }
+  return hex[1] === hex[2] && hex[3] === hex[4] && hex[5] === hex[6] ? "#" + hex[1] + hex[3] + hex[5] : hex;
 }
 
 export const App = React.createClass({


### PR DESCRIPTION
- The color optimization code was buggy for some colors such as fuchsia (#FF00FF) which was wrongly converted to red (#F00).
RRGGBB colors were converted to 3-character-length notation RGG when possible and not RGB!

- The use of CSS color names (and not hexadecimal notation) allow smaller notations which means a smaller output result.